### PR TITLE
[REFACTOR] Use async/await

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,6 +259,8 @@ const HomeNode = module.exports = {
     } else {
       HomeNode.instanceMap[`plugin:${deviceConfig.plugin}`][`device:${id}`] = {};
     }
+
+    return deviceInstance;
   },
 
   getDevice: (id) => {

--- a/index.js
+++ b/index.js
@@ -319,19 +319,30 @@ const HomeNode = module.exports = {
     SysLogger.log('Datastore restore complete.');
 
     SysLogger.log('Restoring device traits...');
-    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => device.restoreTraits()));
+    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => {
+      SysLogger.log(`Restoring device traits for: ${device.id}`);
+      return device.restoreTraits();
+    }));
     SysLogger.log('Device traits restored.');
 
     SysLogger.log('Starting Interfaces...');
-    await Promise.all(Object.values(HomeNode.instances.interfaces).map((interfaceInstance) => interfaceInstance.startup()));
+    await Promise.all(Object.values(HomeNode.instances.interfaces).map((interfaceInstance) => {
+      SysLogger.log(`Starting interface: ${interfaceInstance.id}`);
+      return interfaceInstance.startup();
+    }));
     SysLogger.log('Interfaces startup complete.');
 
     SysLogger.log('Starting Devices...');
-    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => device.startup()));
+    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => {
+      SysLogger.log(`Starting device: ${device.id}`);
+      return device.startup();
+    }));
     SysLogger.log('Devices startup complete.');
 
     SysLogger.log('Starting polling on devices...');
     await Promise.all(Object.values(HomeNode.instances.devices).map((device) => Promise.all(Object.entries(device.polling).map(async ([pollId, poll]) => {
+      SysLogger.log(`Registering polling (${pollId}) on device (${device.id})`);
+
       setInterval(() => device.runPoll(pollId), poll.secs * 1000);
 
       if (poll.runAtStartup) {
@@ -341,7 +352,10 @@ const HomeNode = module.exports = {
     SysLogger.log('Devices polling setup complete.');
 
     SysLogger.log('Starting automations...');
-    await Promise.all(Object.values(HomeNode.instances.automations).map((automation) => automation.startup()));
+    await Promise.all(Object.values(HomeNode.instances.automations).map((automation) => {
+      SysLogger.log(`Starting automation: ${automation.id}`);
+      return automation.startup();
+    }));
     SysLogger.log('Automations started.');
   },
 

--- a/index.js
+++ b/index.js
@@ -120,16 +120,14 @@ const HomeNode = module.exports = {
     ];
 
     Validator.validateKeys(name, keys, required, optional);
-
-    return true;
   },
 
   registerInterface: (config) => {
-    if (HomeNode.validateInterface(config)) {
-      HomeNode.types.interfaces[config.type] = config;
+    HomeNode.validateInterface(config);
 
-      HomeNode.systemMap[`plugin:${config.plugin}`][`interface:${config.type}`] = {};
-    }
+    HomeNode.types.interfaces[config.type] = config;
+
+    HomeNode.systemMap[`plugin:${config.plugin}`][`interface:${config.type}`] = {};
   },
 
   validateInterfaceInstance: (config) => {
@@ -147,32 +145,30 @@ const HomeNode = module.exports = {
     ];
 
     Validator.validateKeys(name, keys, required, optional);
-
-    return true;
   },
 
   interface: (instanceConfig) => {
-    if (HomeNode.validateInterfaceInstance(instanceConfig)) {
-      if (!HomeNode.types.plugins[instanceConfig.plugin]) {
-        throw new Error(`ERROR: Plugin (${instanceConfig.plugin}) is not loaded.`);
-      }
+    HomeNode.validateInterfaceInstance(instanceConfig);
 
-      if (!HomeNode.types.interfaces[instanceConfig.type]) {
-        throw new Error(`ERROR: Interface type (${instanceConfig.type}) is not loaded.`);
-      }
-
-      // Create a instance of the interface
-      const id = instanceConfig.id;
-      const type = instanceConfig.type;
-      const interfaceConfig = HomeNode.types.interfaces[type];
-      const interfaceInstance = new Interface(HomeNode, interfaceConfig, instanceConfig);
-
-      HomeNode.registerInstance('interfaces', id, interfaceInstance);
-
-      HomeNode.instanceMap[`plugin:${interfaceConfig.plugin}`][`interface:${id}`] = {};
-
-      return interfaceInstance;
+    if (!HomeNode.types.plugins[instanceConfig.plugin]) {
+      throw new Error(`ERROR: Plugin (${instanceConfig.plugin}) is not loaded.`);
     }
+
+    if (!HomeNode.types.interfaces[instanceConfig.type]) {
+      throw new Error(`ERROR: Interface type (${instanceConfig.type}) is not loaded.`);
+    }
+
+    // Create a instance of the interface
+    const id = instanceConfig.id;
+    const type = instanceConfig.type;
+    const interfaceConfig = HomeNode.types.interfaces[type];
+    const interfaceInstance = new Interface(HomeNode, interfaceConfig, instanceConfig);
+
+    HomeNode.registerInstance('interfaces', id, interfaceInstance);
+
+    HomeNode.instanceMap[`plugin:${interfaceConfig.plugin}`][`interface:${id}`] = {};
+
+    return interfaceInstance;
   },
 
   getInterface: (id) => {
@@ -211,19 +207,17 @@ const HomeNode = module.exports = {
     ];
 
     Validator.validateKeys(name, keys, required, optional);
-
-    return true;
   },
 
   registerDevice: (config) => {
-    if (HomeNode.validateDevice(config)) {
-      HomeNode.types.devices[config.type] = config;
+    HomeNode.validateDevice(config);
 
-      if (config.interface) {
-        HomeNode.systemMap[`plugin:${config.plugin}`][`interface:${config.interface}`][`device:${config.type}`] = {};
-      } else {
-        HomeNode.systemMap[`plugin:${config.plugin}`][`device:${config.type}`] = {};
-      }
+    HomeNode.types.devices[config.type] = config;
+
+    if (config.interface) {
+      HomeNode.systemMap[`plugin:${config.plugin}`][`interface:${config.interface}`][`device:${config.type}`] = {};
+    } else {
+      HomeNode.systemMap[`plugin:${config.plugin}`][`device:${config.type}`] = {};
     }
   },
 
@@ -243,31 +237,27 @@ const HomeNode = module.exports = {
     ];
 
     Validator.validateKeys(name, keys, required, optional);
-
-    return true;
   },
 
   device: (instanceConfig) => {
-    if (HomeNode.validateDeviceInstance(instanceConfig)) {
-      // Create a instance of the interface
-      const id = instanceConfig.id;
-      const type = instanceConfig.type;
-      const deviceConfig = HomeNode.types.devices[type];
-      const deviceInstance = new Device(HomeNode, deviceConfig, instanceConfig);
+    HomeNode.validateDeviceInstance(instanceConfig);
 
-      if (deviceConfig.interface && !instanceConfig.interface_id) {
-        throw new Error(`ERROR: Device interface is required on device (${id}) please add interface_id to .device() config`);
-      }
+    // Create a instance of the interface
+    const id = instanceConfig.id;
+    const type = instanceConfig.type;
+    const deviceConfig = HomeNode.types.devices[type];
+    const deviceInstance = new Device(HomeNode, deviceConfig, instanceConfig);
 
-      HomeNode.registerInstance('devices', id, deviceInstance);
+    if (deviceConfig.interface && !instanceConfig.interface_id) {
+      throw new Error(`ERROR: Device interface is required on device (${id}) please add interface_id to .device() config`);
+    }
 
-      if (deviceConfig.interface) {
-        HomeNode.instanceMap[`plugin:${deviceConfig.plugin}`][`interface:${instanceConfig.interface_id}`][`device:${id}`] = {};
-      } else {
-        HomeNode.instanceMap[`plugin:${deviceConfig.plugin}`][`device:${id}`] = {};
-      }
+    HomeNode.registerInstance('devices', id, deviceInstance);
 
-      return deviceInstance;
+    if (deviceConfig.interface) {
+      HomeNode.instanceMap[`plugin:${deviceConfig.plugin}`][`interface:${instanceConfig.interface_id}`][`device:${id}`] = {};
+    } else {
+      HomeNode.instanceMap[`plugin:${deviceConfig.plugin}`][`device:${id}`] = {};
     }
   },
 
@@ -297,20 +287,18 @@ const HomeNode = module.exports = {
     ];
 
     Validator.validateKeys(name, keys, required, optional);
-
-    return true;
   },
 
   automation: (instanceConfig) => {
-    if (HomeNode.validateAutomationInstance(instanceConfig)) {
-      // Create a instance of the automation
-      const id = instanceConfig.id;
-      const automationInstance = new Automation(HomeNode, instanceConfig);
+    HomeNode.validateAutomationInstance(instanceConfig);
 
-      HomeNode.instances.automations[id] = automationInstance;
+    // Create a instance of the automation
+    const id = instanceConfig.id;
+    const automationInstance = new Automation(HomeNode, instanceConfig);
 
-      HomeNode.instanceMap[`automations:${id}`] = {};
-    }
+    HomeNode.instances.automations[id] = automationInstance;
+
+    HomeNode.instanceMap[`automations:${id}`] = {};
   },
 
   getAutomation: (id) => {
@@ -321,117 +309,38 @@ const HomeNode = module.exports = {
     return HomeNode.instances.automations[id];
   },
 
-  start: () => {
+  start: async () => {
     SysLogger.log('Starting up...');
 
-    let startupSequence = Promise.resolve();
+    SysLogger.log('Restoring datastore...');
+    await Datastore.startup();
+    SysLogger.log('Datastore restore complete.');
 
-    // Restore Datastore
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Restoring datastore...');
-    });
+    SysLogger.log('Restoring device traits...');
+    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => device.restoreTraits()));
+    SysLogger.log('Device traits restored.');
 
-    startupSequence = startupSequence.then(() => {
-      return Datastore.startup();
-    });
+    SysLogger.log('Starting Interfaces...');
+    await Promise.all(Object.values(HomeNode.instances.interfaces).map((interfaceInstance) => interfaceInstance.startup()));
+    SysLogger.log('Interfaces startup complete.');
 
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Datastore restore complete.');
-    });
+    SysLogger.log('Starting Devices...');
+    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => device.startup()));
+    SysLogger.log('Devices startup complete.');
 
-    // Restore Device Traits
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Restoring device traits...');
-    });
+    SysLogger.log('Starting polling on devices...');
+    await Promise.all(Object.values(HomeNode.instances.devices).map((device) => Promise.all(Object.entries(device.polling).map(async ([pollId, poll]) => {
+      setInterval(() => device.runPoll(pollId), poll.secs * 1000);
 
-    startupSequence = startupSequence.then(() => {
-      _.each(HomeNode.instances.devices, (device) => {
-        device.restoreTraits();
-      });
-    });
+      if (poll.runAtStartup) {
+        await device.runPoll(pollId);
+      }
+    }))));
+    SysLogger.log('Devices polling setup complete.');
 
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Device traits restored.');
-    });
-
-    // Start Interfaces
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Starting Interfaces...');
-    });
-
-    startupSequence = _.reduce(HomeNode.instances.interfaces, (promiseChain, instance, id) => {
-      return promiseChain.then(() => {
-        SysLogger.log(`Starting interface: ${id}`);
-        return instance.startup();
-      });
-    }, startupSequence);
-
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Interfaces startup complete.');
-    });
-
-    // Start Devices
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Starting Devices...');
-    });
-
-    startupSequence = _.reduce(HomeNode.instances.devices, (promiseChain, instance, id) => {
-      return promiseChain.then(() => {
-        SysLogger.log(`Starting device: ${id}`);
-        return instance.startup();
-      });
-    }, startupSequence);
-
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Devices startup complete.');
-    });
-
-    // Start polling devices
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Starting polling on devices...');
-    });
-
-    startupSequence = _.reduce(HomeNode.instances.devices, (promiseChain, instance, deviceId) => {
-      // Step into polling on each device
-      return promiseChain.then(() => {
-        return _.reduce(instance.polling, (promiseChain, poll, pollId) => {
-          return promiseChain.then(() => {
-            SysLogger.log(`Registering polling (${pollId}) on device (${deviceId})`);
-
-            // Register poll
-            setInterval(() => {
-              instance.runPoll(pollId);
-            }, poll.secs * 1000);
-
-            // Optionally run at startup
-            if (poll.runAtStartup) {
-              return instance.runPoll(pollId);
-            }
-          });
-        }, promiseChain);
-      });
-    }, startupSequence);
-
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Devices polling setup complete.');
-    });
-
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Starting automations...');
-    });
-
-    startupSequence = startupSequence.then(() => {
-      _.each(HomeNode.instances.automations, (automation, id) => {
-        SysLogger.log(`Starting automation: ${id}`);
-        automation.startup();
-      });
-    });
-
-    startupSequence = startupSequence.then(() => {
-      SysLogger.log('Automations started.');
-    });
-
-    return startupSequence;
+    SysLogger.log('Starting automations...');
+    await Promise.all(Object.values(HomeNode.instances.automations).map((automation) => automation.startup()));
+    SysLogger.log('Automations started.');
   },
 
   stop: () => {

--- a/lib/datastore.js
+++ b/lib/datastore.js
@@ -1,47 +1,46 @@
-const loki = require("lokijs");
+const loki = require('lokijs');
+
 let db;
 
 const now = () => Math.floor(Date.now() / 1000);
 
-const format = (record) => {
-  return {
-    value: record.value,
-    lastUpdated: record.lastUpdated,
-    lastChanged: record.lastChanged,
-  };
-};
+const format = (record) => ({
+  value: record.value,
+  lastUpdated: record.lastUpdated,
+  lastChanged: record.lastChanged,
+});
 
 module.exports = {
-  startup: () => {
-    return new Promise((resolve, reject) => {
-      db = new loki('homenode.db', {
-        autoload: true,
-        autosave: true,
-        autosaveInterval: 1000,
-        autoloadCallback: () => {
-          if (!db.getCollection('traits')) {
-            console.log('Create traits table');
-            db.addCollection('traits');
-          }
+  startup: () => new Promise((resolve, reject) => {
+    db = new loki('homenode.db', {
+      autoload: true,
+      autosave: true,
+      autosaveInterval: 1000,
+      autoloadCallback: () => {
+        if (!db.getCollection('traits')) {
+          console.log('Create traits table');
+          db.addCollection('traits');
+        }
 
-          resolve();
-        },
-      });
+        resolve();
+      },
     });
-  },
+  }),
+
   get: (collection, id) => {
     const table = db.getCollection(collection);
-    const record = table.findOne({id});
+    const record = table.findOne({ id });
 
-    return record && format(record) || null;
+    return (record && format(record)) || null;
   },
+
   set: (collection, id, value) => {
     const table = db.getCollection(collection);
-    const record = table.findOne({id});
+    const record = table.findOne({ id });
     const nowTimestamp = now();
 
     if (record) {
-      //console.log('Updating record', collection, id, value);
+      // console.log('Updating record', collection, id, value);
       record.lastUpdated = nowTimestamp;
 
       // Track a timestamp if the value cahgnes
@@ -53,15 +52,15 @@ module.exports = {
       table.update(record);
 
       return format(record);
-    } else {
-      //console.log('Inserting record', collection, id, value);
-      const newRecord = table.insert({
-        id,
-        value,
-        lastUpdated: nowTimestamp,
-        lastChanged: nowTimestamp,
-      });
-      return format(newRecord);
     }
+    // console.log('Inserting record', collection, id, value);
+    const newRecord = table.insert({
+      id,
+      value,
+      lastUpdated: nowTimestamp,
+      lastChanged: nowTimestamp,
+    });
+
+    return format(newRecord);
   },
 };

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -13,7 +13,5 @@ module.exports = {
     if (extra.length) {
       throw new Error(`ERROR: Extra config properties (${extra.join(', ')}) for ${name}`);
     }
-
-    return true;
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,11 +1382,6 @@
         }
       }
     },
-    "invert-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-color/-/invert-color-2.0.0.tgz",
-      "integrity": "sha512-9s6IATlhOAr0/0MPUpLdMpk81ixIu8IqwPwORssXBauFT/4ff/iyEOcojd0UYuPwkDbJvL1+blIZGhqVIaAm5Q=="
-    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -2382,11 +2377,6 @@
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
       "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
       "dev": true
-    },
-    "randomcolor": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/randomcolor/-/randomcolor-0.5.4.tgz",
-      "integrity": "sha512-nYd4nmTuuwMFzHL6W+UWR5fNERGZeVauho8mrJDUSXdNDbao4rbrUwhuLgKC/j8VCS5+34Ria8CsTDuBjrIrQA=="
     },
     "read-pkg": {
       "version": "2.0.0",

--- a/sample-app/app.js
+++ b/sample-app/app.js
@@ -74,26 +74,30 @@ HomeNode.automation({
 
 HomeNode.tree();
 
-HomeNode.start().then(() => {
+const boot = async () => {
+  await HomeNode.start();
+
   const Time = HomeNode.getDevice('time');
 
   Time.onTraitChange('time', (newTrait, oldTrait) => {
-    //console.log('time:', newTrait.value, oldTrait.value);
+    // console.log('time:', newTrait.value, oldTrait.value);
   });
 
   Time.setTrait('solarNoon', '10:15 pm');
 
   Time.onEvent('solarNoon', () => {
-    //console.log('event: solarNoon!');
+    // console.log('event: solarNoon!');
   });
 
   const fakeSwitch = HomeNode.getDevice('fake-switch');
 
   fakeSwitch.onTraitChange('power', (newT, oldT) => {
-    //console.log('SWITCH CHANGE!', newT, oldT);
+    // console.log('SWITCH CHANGE!', newT, oldT);
   });
 
   const powerTrait = fakeSwitch.getTrait('power');
 
   fakeSwitch.setTrait('power', !powerTrait.value);
-});
+};
+
+boot();


### PR DESCRIPTION
Converts `HomeNode.start` to async/await.

Shouldn't have any functional differences besides the fact that `Promise.all` means everything in that step will boot together instead of one at a time with the previous `.reduce` pattern. I was thinking that probably didn't matter anyways though since we are reducing an object. An object's property order is not guaranteed, so thinking those would reduce in a certain order can't be guaranteed either.. Maybe switching `HomeNode.instances` from objects to arrays will be something we have to think about in the future if order becomes important.

I also cleaned up bool checks similar to `if (HomeNode.validateDeviceInstance(instanceConfig)) {` since throwing an error in `validateKeys` would already have stopped the execution of that validator.

The rest of the changes were just some ES6 & ESLint cleanup.

Easiest reviewed with [?w=1](https://github.com/homenode/homenode/pull/1/files?w=1) due to a number of indenting changes.